### PR TITLE
changed base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,18 @@
-FROM tensorflow/tensorflow:1.9.0-rc0-devel-py3
+FROM continuumio/miniconda3
 
-RUN apt-get update && apt-get install -y libopenslide0 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libopenslide0 gcc && rm -rf /var/lib/apt/lists/*
 
 # Python package versions
 ARG numpy_version=1.14.1
+ARG tensorflow_version=1.9.0
 
 RUN pip install --upgrade pip && \
-	pip install numpy==${numpy_version} && \
+    pip install numpy==${numpy_version} && \
     pip install Pillow && \
     pip install h5py && \
     pip install flask-restplus && \
-    pip install openslide-python
+    pip install openslide-python && \
+    pip install tensorflow==${tensorflow_version}
 
 RUN mkdir /workspace && \
     cd /workspace && \


### PR DESCRIPTION
Now that Tensorflow 1.9.0 is available in PyPi we can download it there instead of using a specific docker image.